### PR TITLE
Update ReplaceHashTag.js

### DIFF
--- a/js/src/forum/ReplaceHashTag.js
+++ b/js/src/forum/ReplaceHashTag.js
@@ -1,7 +1,7 @@
 import app from 'flarum/forum/app';
 
 export default function () {
-  const regex = /(?<=\s|^)#(\w*[A-Za-z_]+\w*)/g;
+  const regex = /(^|\s)#(\p{L}+)/gu;
   const p = this.$('p');
   const discussionsUrl = app.route('index');
   const tooltip = app.translator.trans('justoverclock-hashtag.forum.post.hashtag_link_tooltip');
@@ -12,7 +12,7 @@ export default function () {
     $(element).html(
       $(element)
         .html()
-        .replace(regex, (match) => `<a href="${discussionsUrl}?q=${match.slice(1)}" class="hasht" title="${tooltip}">${match}</a>`)
+        .replace(regex, (match) => ` <a href="${discussionsUrl}?q=${match.slice(1)}" class="hasht" title="${tooltip}">${match}</a>`)
     );
     setTimeout(() => {
       $(element)


### PR DESCRIPTION
Regular expression works in Safari and all languages. Adding space within line 15 just before anchor takes care of spaces at beginning being detected.