### PR TITLE
Replace with TextFormatter plugin

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -12,7 +12,7 @@
 namespace Justoverclock\Hashtag;
 
 use Flarum\Extend;
-use Flarum\Api\Event\Serializing;
+use Flarum\Settings\Event\Saving as SettingsSaving;
 use s9e\TextFormatter\Configurator;
 
 return [
@@ -25,5 +25,16 @@ return [
     (new Extend\Formatter())
         ->configure(function (Configurator $configurator) {
             $configurator->plugins->set('Hashtag', Plugins\Hashtag\Configurator::class);
-        })
+        }),
+
+    (new Extend\Event())
+        ->listen(SettingsSaving::class, function (SettingsSaving $event) {
+            foreach ($event->settings as $key => $setting) {
+                if ($key === 'justoverclock-hashtag.regex') {
+                    resolve('flarum.formatter')->flush();
+
+                    return;
+                }
+            }
+        }),
 ];

--- a/extend.php
+++ b/extend.php
@@ -13,6 +13,7 @@ namespace Justoverclock\Hashtag;
 
 use Flarum\Extend;
 use Flarum\Api\Event\Serializing;
+use s9e\TextFormatter\Configurator;
 
 return [
     (new Extend\Frontend('forum'))
@@ -21,6 +22,8 @@ return [
     (new Extend\Frontend('admin'))
         ->js(__DIR__.'/js/dist/admin.js'),
     new Extend\Locales(__DIR__.'/resources/locale'),
-    (new Extend\Settings())
-    ->serializeToForum('justoverclock-hashtag.regex', 'justoverclock-hashtag.regex'),
+    (new Extend\Formatter())
+        ->configure(function (Configurator $configurator) {
+            $configurator->plugins->set('Hashtag', Plugins\Hashtag\Configurator::class);
+        })
 ];

--- a/extend.php
+++ b/extend.php
@@ -30,7 +30,7 @@ return [
     (new Extend\Event())
         ->listen(SettingsSaving::class, function (SettingsSaving $event) {
             foreach ($event->settings as $key => $setting) {
-                if ($key === 'justoverclock-hashtag.regex') {
+                if ($key === 'justoverclock-hashtag.regex' || $key === 'default_route') {
                     resolve('flarum.formatter')->flush();
 
                     return;

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -1,14 +1,11 @@
 import app from 'flarum/admin/app';
 
-
 app.initializers.add('justoverclock-hashtag', () => {
-  app.extensionData
-    .for('justoverclock-hashtag')
-    .registerSetting({
-      setting: 'justoverclock-hashtag.regex',
-      name: 'justoverclock-hashtag.regex',
-      type: 'text',
-      label: app.translator.trans('justoverclock-hashtag.admin.settings.regexlabel'),
-      help: app.translator.trans('justoverclock-hashtag.admin.settings.regexdesc'),
-    });
+  app.extensionData.for('justoverclock-hashtag').registerSetting({
+    setting: 'justoverclock-hashtag.regex',
+    name: 'justoverclock-hashtag.regex',
+    type: 'text',
+    label: app.translator.trans('justoverclock-hashtag.admin.settings.regexlabel'),
+    help: app.translator.trans('justoverclock-hashtag.admin.settings.regexdesc'),
+  });
 });

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -1,11 +1,25 @@
 import app from 'flarum/admin/app';
 
 app.initializers.add('justoverclock-hashtag', () => {
+  const oldRegex = app.data.settings['justoverclock-hashtag.regex.old'];
+
   app.extensionData.for('justoverclock-hashtag').registerSetting({
     setting: 'justoverclock-hashtag.regex',
     name: 'justoverclock-hashtag.regex',
     type: 'text',
     label: app.translator.trans('justoverclock-hashtag.admin.settings.regexlabel'),
-    help: app.translator.trans('justoverclock-hashtag.admin.settings.regexdesc'),
+    placeholder: String.raw`/\B#(\w+)(?!#)\b/`,
+    help: (
+      <p>
+        {app.translator.trans('justoverclock-hashtag.admin.settings.regexdesc')}
+
+        {oldRegex && (
+          <span>
+            <br />
+            {app.translator.trans('justoverclock-hashtag.admin.settings.oldregexdesc', { regex: oldRegex })}
+          </span>
+        )}
+      </p>
+    ),
   });
 });

--- a/js/src/forum/ReplaceHashTag.js
+++ b/js/src/forum/ReplaceHashTag.js
@@ -1,28 +1,11 @@
 import app from 'flarum/forum/app';
 
 export default function () {
-
-  const regex = /#[^\s!@#$%^&*()=+.\/,\[{\]};:'"?><]+/gu;
-  const p = this.$('p');
-  const discussionsUrl = app.route('index');
-  const tooltip = app.translator.trans('justoverclock-hashtag.forum.post.hashtag_link_tooltip');
-
-  // rimuoviamo il carattere # utilizzando match.slice nel link
-  // thanks to Nearata for this fix
-  p.each((index, element) => {
-    $(element).html(
-      $(element)
-        .html()
-        .replace(regex, (match) => ` <a href="${discussionsUrl}?q=${match.replace(/#/g,'').trim()}" class="hasht" title="${tooltip}">${match.trim()}</a>`)
-    );
-    setTimeout(() => {
-      $(element)
-        .find('a.hasht')
-        .click((e) => {
-          if (e.ctrlKey || e.metaKey || e.which === 2) return;
-          e.preventDefault();
-          m.route.set(e.target.href);
-        });
-    }, 1);
-  });
+  this.$('a.hasht')
+    .attr('title', app.translator.trans('justoverclock-hashtag.forum.post.hashtag_link_tooltip'))
+    .click((e) => {
+      if (e.ctrlKey || e.metaKey || e.which === 2) return;
+      e.preventDefault();
+      m.route.set(e.target.href);
+    });
 }

--- a/migrations/2022_03_20_000000_backup_old_custom_regex.php
+++ b/migrations/2022_03_20_000000_backup_old_custom_regex.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        /**
+         * @var \Flarum\Settings\SettingsRepositoryInterface
+         */
+        $settings = resolve('flarum.settings');
+
+        $value = $settings->get($key = 'justoverclock-hashtag.regex');
+
+        if (isset($value)) {
+            $settings->set('justoverclock-hashtag.regex.old', $value);
+            $settings->delete($key);
+        }
+    },
+    'down' => function (Builder $schema) {
+        // ...
+    }
+];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -3,6 +3,7 @@ justoverclock-hashtag:
     settings:
       regexlabel: Hashtag Regular Expression
       regexdesc: An example is shown below as the placeholder. Only edit if you understand Regular Expressions.
+      oldregexdesc: "Here is your old hashtag regular expression: <code>{regex}</code>"
   forum:
     post:
       hashtag_link_tooltip: Find posts related to this hashtag

--- a/src/Plugins/Hashtag/Configurator.php
+++ b/src/Plugins/Hashtag/Configurator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Justoverclock\Hashtag\Plugins\Hashtag;
+
+use Flarum\Http\UrlGenerator;
+use s9e\TextFormatter\Plugins\ConfiguratorBase;
+
+class Configurator extends ConfiguratorBase
+{
+    protected $regexp = '/\B#(\w+)(?!#)\b/';
+    protected $tagName = 'HASHTAG';
+
+    protected function setUp()
+    {
+        $forumUrl = resolve(UrlGenerator::class)->to('forum');
+
+        $indexRoute = $forumUrl->route('index');
+        $defaultRoute = resolve('flarum.settings')->get('default_route');
+
+        // If the default route is the index route, we use the base URL to avoid a redirect.
+        $this->configurator->rendering->parameters['SEARCH_URL'] = $defaultRoute === '/all' ? $forumUrl->base() : $indexRoute;
+
+        $tag = $this->configurator->tags->add($this->tagName);
+
+        $tag->attributes->add('query');
+
+        $tag->template = '<a class="hasht" href="{$SEARCH_URL}?q={@query}" title="{@query}">
+            #<xsl:value-of select="@query" />
+        </a>';
+    }
+
+    public function getJSParser()
+    {
+        return \file_get_contents(realpath(__DIR__.'/Parser.js'));
+    }
+}

--- a/src/Plugins/Hashtag/Configurator.php
+++ b/src/Plugins/Hashtag/Configurator.php
@@ -12,6 +12,13 @@ class Configurator extends ConfiguratorBase
 
     protected function setUp()
     {
+        $customRegex = resolve('flarum.settings')->get('justoverclock-hashtag.regex');
+        $isRegexValid = is_int(@preg_match($customRegex, ''));
+
+        if ($customRegex && $isRegexValid) {
+            $this->regexp = $customRegex;
+        }
+
         $forumUrl = resolve(UrlGenerator::class)->to('forum');
 
         $indexRoute = $forumUrl->route('index');

--- a/src/Plugins/Hashtag/Parser.js
+++ b/src/Plugins/Hashtag/Parser.js
@@ -1,0 +1,8 @@
+matches.forEach(function(m)
+{
+  var tag = addSelfClosingTag(config.tagName, m[0][1], m[0][0].length, -10);
+
+  tag.setAttributes({
+    'query':  m[1][0],
+  });
+});

--- a/src/Plugins/Hashtag/Parser.php
+++ b/src/Plugins/Hashtag/Parser.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Justoverclock\Hashtag\Plugins\Hashtag;
+
+use s9e\TextFormatter\Plugins\ParserBase;
+
+class Parser extends ParserBase
+{
+
+    public function parse($text, array $matches)
+    {
+        $tagName = $this->config['tagName'];
+
+        foreach ($matches as $m) {
+            /**
+             * $m looks like the following:
+             * [
+             *   ["#hashtag", 0],
+             *   ["hashtag", 1],
+             * ];
+             */
+
+            $tag = $this->parser->addSelfClosingTag(
+                $tagName,
+                $m[0][1],
+                \strlen($m[0][0]),
+                -10
+            );
+
+            $tag->setAttributes(
+                [
+                    'query'    => $m[1][0],
+                ]
+            );
+        }
+    }
+}


### PR DESCRIPTION
Inspiration taken from `fof/github-autolink` (https://github.com/FriendsOfFlarum/github-autolink/tree/13342fa0fbd9c705bcc3f48bfc3b97ec81d71aaa/src/Plugins/GithubIssue)

**==> I recommend this be released as a major version (in this case, 0.3.0) as the RegExp is changing. Potentially 'breaking' in old functionality/behavior.**

---

I also made it so the custom regexp is reset - however, admins are able to view the one they had before this update.

Changing default route & regexp requires the Formatter cache to be flushed in order for those changes to take effect. So I made it so it is flushed when those settings are changed.

The `default_route` handling is needed because the backend will have `/all` in URL even if that is the default page, making it redirect and then not show the query. The code for handling that only runs when the Formatter is configured, which happens only when its cache has been flushed.

The use of `TextFormatter` means any further updates and/or RegExp changes will only affect future saved/edited posts (unlike using the JS solution).

This means hashtags work during post preview now (though the JS code that makes it use Mithril route doesn't run there).

---

![image](https://user-images.githubusercontent.com/6401250/159175023-9eb0e330-f8cb-4597-b368-75cfeb3cb1dc.png)

The `content` post field saved:
```xsl
<r>
  <p>
    <HASHTAG query="asdasd">#asdasd</HASHTAG>{" "}
    <HASHTAG query="asdasd">#asdasd</HASHTAG> #hello#there{" "}
    <HASHTAG query="asdasd11">#asdasd11</HASHTAG>???{" "}
    <HASHTAG query="asdGY">#asdGY</HASHTAG>*<HASHTAG query="OL">#OL</HASHTAG>
  </p>
</r>
```